### PR TITLE
Add freelance invoice generator page

### DIFF
--- a/invoice.html
+++ b/invoice.html
@@ -1,0 +1,533 @@
+<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Créateur de factures freelance</title>
+    <link
+      rel="preconnect"
+      href="https://fonts.googleapis.com"
+      crossorigin
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        color-scheme: light;
+        font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+          sans-serif;
+        --bg: #f5f5f7;
+        --card: #ffffff;
+        --border: #d6d6dd;
+        --text: #1f1f24;
+        --muted: #5f5f6b;
+        --accent: #4f46e5;
+        --accent-contrast: #ffffff;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        background: var(--bg);
+        color: var(--text);
+        line-height: 1.5;
+      }
+
+      main {
+        max-width: 1100px;
+        margin: 0 auto;
+        padding: 3rem 1.5rem 4rem;
+        display: flex;
+        flex-direction: column;
+        gap: 2.5rem;
+      }
+
+      header h1 {
+        font-size: clamp(2.25rem, 4vw, 3rem);
+        margin: 0 0 0.5rem;
+        font-weight: 700;
+      }
+
+      header p {
+        margin: 0;
+        color: var(--muted);
+        max-width: 65ch;
+      }
+
+      .invoice-card {
+        background: var(--card);
+        border-radius: 20px;
+        box-shadow: 0 20px 35px rgba(15, 23, 42, 0.08);
+        padding: clamp(1.5rem, 3vw, 2.5rem);
+        display: flex;
+        flex-direction: column;
+        gap: 2rem;
+      }
+
+      .flex {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 2rem;
+      }
+
+      .panel {
+        flex: 1 1 250px;
+        min-width: 220px;
+      }
+
+      .panel h2 {
+        font-size: 1rem;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: var(--muted);
+        margin: 0 0 0.75rem;
+      }
+
+      .panel p,
+      .panel textarea,
+      .panel input {
+        margin: 0;
+        font-size: 1rem;
+      }
+
+      .panel textarea,
+      .panel input,
+      .panel [contenteditable="true"] {
+        width: 100%;
+        border: 1px solid var(--border);
+        border-radius: 12px;
+        padding: 0.75rem 1rem;
+        background: #fafafa;
+        color: inherit;
+        font: inherit;
+        resize: vertical;
+      }
+
+      .panel textarea {
+        min-height: 120px;
+      }
+
+      .panel input[type="date"],
+      .panel input[type="text"] {
+        height: 46px;
+      }
+
+      label {
+        display: flex;
+        flex-direction: column;
+        gap: 0.4rem;
+        font-weight: 600;
+        color: var(--muted);
+        margin-bottom: 1rem;
+      }
+
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        border-radius: 16px;
+        overflow: hidden;
+        box-shadow: 0 0 0 1px var(--border);
+      }
+
+      thead {
+        background: #f3f3f8;
+        color: var(--muted);
+        text-transform: uppercase;
+        font-size: 0.75rem;
+        letter-spacing: 0.08em;
+      }
+
+      th,
+      td {
+        padding: 0.95rem 1rem;
+        text-align: left;
+        border-bottom: 1px solid var(--border);
+      }
+
+      tbody tr:last-child td {
+        border-bottom: none;
+      }
+
+      tbody input[type="text"],
+      tbody input[type="number"] {
+        width: 100%;
+        border: 1px solid transparent;
+        background: transparent;
+        padding: 0.4rem 0.2rem;
+        font: inherit;
+        color: inherit;
+        border-radius: 8px;
+        transition: border 0.2s ease, background 0.2s ease;
+      }
+
+      tbody input[type="text"]:focus,
+      tbody input[type="number"]:focus {
+        outline: none;
+        border-color: var(--accent);
+        background: rgba(79, 70, 229, 0.08);
+      }
+
+      tbody input[type="number"]::-webkit-outer-spin-button,
+      tbody input[type="number"]::-webkit-inner-spin-button {
+        -webkit-appearance: none;
+        margin: 0;
+      }
+
+      tbody input[type="number"] {
+        appearance: textfield;
+        text-align: right;
+      }
+
+      .line-total {
+        font-weight: 600;
+        text-align: right;
+      }
+
+      .actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 1rem;
+        justify-content: flex-end;
+      }
+
+      button {
+        border: none;
+        border-radius: 999px;
+        padding: 0.8rem 1.6rem;
+        font-weight: 600;
+        cursor: pointer;
+        display: inline-flex;
+        align-items: center;
+        gap: 0.6rem;
+        font-size: 1rem;
+      }
+
+      .btn-secondary {
+        background: #e8e8f6;
+        color: var(--accent);
+      }
+
+      .btn-primary {
+        background: var(--accent);
+        color: var(--accent-contrast);
+        box-shadow: 0 10px 20px rgba(79, 70, 229, 0.25);
+      }
+
+      .btn-danger {
+        background: #fee2e2;
+        color: #b91c1c;
+        font-size: 0.95rem;
+        padding: 0.45rem 0.9rem;
+      }
+
+      .totals {
+        margin-left: auto;
+        width: min(320px, 100%);
+        display: grid;
+        gap: 0.5rem;
+        border: 1px solid var(--border);
+        border-radius: 16px;
+        padding: 1.5rem;
+        background: #fafaff;
+      }
+
+      .totals-row {
+        display: flex;
+        justify-content: space-between;
+        font-weight: 600;
+        color: var(--muted);
+      }
+
+      .grand-total {
+        font-size: 1.35rem;
+        font-weight: 700;
+        color: var(--accent);
+      }
+
+      @media (max-width: 720px) {
+        th,
+        td {
+          padding: 0.75rem 0.8rem;
+        }
+
+        .panel input,
+        .panel textarea,
+        .panel [contenteditable="true"] {
+          padding: 0.65rem 0.8rem;
+        }
+
+        .invoice-card {
+          padding: 1.5rem;
+          gap: 1.5rem;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <header>
+        <h1>Outil de création de factures freelance</h1>
+        <p>
+          Préparez votre facture en ajoutant vos missions et prestations. Les
+          données restent sur votre appareil : rien n'est stocké côté serveur.
+        </p>
+      </header>
+
+      <div class="invoice-card" id="invoice-preview">
+        <section class="flex">
+          <div class="panel">
+            <h2>Émetteur</h2>
+            <textarea
+              id="issuer-details"
+              placeholder="Votre nom\nAdresse\nSIRET\nEmail"
+            ></textarea>
+          </div>
+          <div class="panel">
+            <h2>Client</h2>
+            <textarea
+              id="client-details"
+              placeholder="Nom du client\nAdresse\nContact"
+            ></textarea>
+          </div>
+        </section>
+
+        <section class="flex">
+          <div class="panel">
+            <h2>Facture</h2>
+            <label for="invoice-number">Numéro de facture</label>
+            <input
+              type="text"
+              id="invoice-number"
+              placeholder="2024-001"
+              autocomplete="off"
+            />
+            <label for="invoice-date">Date d'émission</label>
+            <input type="date" id="invoice-date" />
+            <label for="invoice-due">Date d'échéance</label>
+            <input type="date" id="invoice-due" />
+          </div>
+          <div class="panel">
+            <h2>Notes</h2>
+            <textarea
+              id="invoice-notes"
+              placeholder="Conditions de paiement, informations complémentaires..."
+            ></textarea>
+          </div>
+        </section>
+
+        <section>
+          <table aria-label="Lignes de facturation">
+            <thead>
+              <tr>
+                <th scope="col">Description</th>
+                <th scope="col">Taux horaire (€)</th>
+                <th scope="col">Heures / jour</th>
+                <th scope="col">Nombre de jours</th>
+                <th scope="col">Total de la ligne</th>
+                <th scope="col" aria-label="Actions"></th>
+              </tr>
+            </thead>
+            <tbody id="service-body"></tbody>
+          </table>
+          <div class="actions">
+            <button class="btn-secondary" id="add-line" type="button">
+              ➕ Ajouter une ligne
+            </button>
+          </div>
+        </section>
+
+        <section class="totals" aria-live="polite">
+          <div class="totals-row">
+            <span>Total HT</span>
+            <span id="total-amount">0,00 €</span>
+          </div>
+          <div class="totals-row grand-total">
+            <span>Total à payer</span>
+            <span id="grand-total">0,00 €</span>
+          </div>
+        </section>
+      </div>
+
+      <div class="actions" style="justify-content: flex-start">
+        <button class="btn-primary" id="download-pdf" type="button">
+          📄 Exporter en PDF
+        </button>
+        <button class="btn-secondary" id="reset-invoice" type="button">
+          ♻️ Réinitialiser
+        </button>
+      </div>
+    </main>
+
+    <template id="service-row-template">
+      <tr>
+        <td>
+          <input
+            type="text"
+            class="service-description"
+            placeholder="Intitulé de la prestation"
+          />
+        </td>
+        <td>
+          <input
+            type="number"
+            class="service-rate"
+            inputmode="decimal"
+            step="0.01"
+            min="0"
+            value="0"
+            aria-label="Taux horaire"
+          />
+        </td>
+        <td>
+          <input
+            type="number"
+            class="service-hours"
+            inputmode="decimal"
+            step="0.25"
+            min="0"
+            value="0"
+            aria-label="Heures par jour"
+          />
+        </td>
+        <td>
+          <input
+            type="number"
+            class="service-days"
+            inputmode="decimal"
+            step="0.5"
+            min="0"
+            value="0"
+            aria-label="Nombre de jours"
+          />
+        </td>
+        <td class="line-total">0,00 €</td>
+        <td>
+          <button type="button" class="btn-danger remove-line">✕</button>
+        </td>
+      </tr>
+    </template>
+
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/html2pdf.js/0.9.3/html2pdf.bundle.min.js" integrity="sha512-R4nCTIT0mWvTo2OfzmiEJeZVrDCTnhgypKekJy5o+1OtSWT8gJtIhXCTITVEWilR92qT9bkOuM54bC2K2k+O9A==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script>
+      const serviceBody = document.getElementById("service-body");
+      const addLineButton = document.getElementById("add-line");
+      const template = document.getElementById("service-row-template");
+      const totalAmount = document.getElementById("total-amount");
+      const grandTotal = document.getElementById("grand-total");
+      const resetButton = document.getElementById("reset-invoice");
+      const pdfButton = document.getElementById("download-pdf");
+      const invoiceNumberInput = document.getElementById("invoice-number");
+
+      const currencyFormatter = new Intl.NumberFormat("fr-FR", {
+        style: "currency",
+        currency: "EUR",
+        minimumFractionDigits: 2,
+      });
+
+      function parseInputValue(input) {
+        const value = parseFloat(input.value.replace(",", "."));
+        return Number.isFinite(value) ? value : 0;
+      }
+
+      function updateTotals() {
+        const rows = serviceBody.querySelectorAll("tr");
+        let sum = 0;
+
+        rows.forEach((row) => {
+          const rateInput = row.querySelector(".service-rate");
+          const hoursInput = row.querySelector(".service-hours");
+          const daysInput = row.querySelector(".service-days");
+          const lineTotalCell = row.querySelector(".line-total");
+
+          const rate = parseInputValue(rateInput);
+          const hours = parseInputValue(hoursInput);
+          const days = parseInputValue(daysInput);
+
+          const total = rate * hours * days;
+          lineTotalCell.textContent = currencyFormatter.format(total);
+          sum += total;
+        });
+
+        totalAmount.textContent = currencyFormatter.format(sum);
+        grandTotal.textContent = currencyFormatter.format(sum);
+      }
+
+      function addRow(initialData = {}) {
+        const clone = template.content.cloneNode(true);
+        const row = clone.querySelector("tr");
+        const [description, rate, hours, days] = [
+          row.querySelector(".service-description"),
+          row.querySelector(".service-rate"),
+          row.querySelector(".service-hours"),
+          row.querySelector(".service-days"),
+        ];
+
+        description.value = initialData.description || "";
+        rate.value = initialData.rate ?? 0;
+        hours.value = initialData.hours ?? 0;
+        days.value = initialData.days ?? 0;
+
+        row.addEventListener("input", (event) => {
+          if (event.target.matches("input")) {
+            updateTotals();
+          }
+        });
+
+        row.querySelector(".remove-line").addEventListener("click", () => {
+          row.remove();
+          if (!serviceBody.children.length) {
+            addRow();
+          }
+          updateTotals();
+        });
+
+        serviceBody.appendChild(clone);
+        updateTotals();
+      }
+
+      addLineButton.addEventListener("click", () => {
+        addRow();
+      });
+
+      resetButton.addEventListener("click", () => {
+        if (
+          window.confirm(
+            "Voulez-vous vraiment réinitialiser la facture ? Toutes les données seront perdues."
+          )
+        ) {
+          document.getElementById("issuer-details").value = "";
+          document.getElementById("client-details").value = "";
+          document.getElementById("invoice-date").value = "";
+          document.getElementById("invoice-due").value = "";
+          document.getElementById("invoice-notes").value = "";
+          invoiceNumberInput.value = "";
+          serviceBody.innerHTML = "";
+          addRow();
+        }
+      });
+
+      pdfButton.addEventListener("click", () => {
+        updateTotals();
+        const invoiceElement = document.getElementById("invoice-preview");
+        const invoiceNumber = invoiceNumberInput.value.trim() || "freelance";
+        const options = {
+          margin: [12, 12, 12, 12],
+          filename: `facture-${invoiceNumber}.pdf`,
+          image: { type: "jpeg", quality: 0.98 },
+          html2canvas: { scale: 2, useCORS: true },
+          jsPDF: { unit: "mm", format: "a4", orientation: "portrait" },
+        };
+
+        html2pdf().set(options).from(invoiceElement).save();
+      });
+
+      // Initialize with a single empty row
+      addRow();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a standalone invoice generator page tailored for freelance work
- support unlimited service lines with automatic totals and reset controls
- integrate client-side PDF export using html2pdf.js

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68d3e8dc3cfc832ab720345fc06a5998